### PR TITLE
Fixing the template so that the right logo is being used.

### DIFF
--- a/inst/rmarkdown/templates/macquarie/skeleton/beamerthememacquarie.sty
+++ b/inst/rmarkdown/templates/macquarie/skeleton/beamerthememacquarie.sty
@@ -90,7 +90,7 @@
 \setbeamertemplate{title page}
 {
 
-	\begin{textblock}{0}(\MQmargin/\paperwidth,\MQmargin/\paperheight)
+\begin{textblock}{0}(\MQmargin/\paperwidth,\MQmargin/\paperheight)
 		\includegraphics[width=\backwidth, height = \backheight,keepaspectratio=false]{back-title}
 	\end{textblock}
 	\begin{textblock}{0}(\MQmargin/\paperwidth,\bottomtitlepos/\paperheight)
@@ -105,10 +105,12 @@
 	\begin{textblock}{0.9}(0.075,0.28)\usebeamerfont{subtitle}
 		{\color{MQRedText}\insertsubtitle}
 	\end{textblock}
-	\begin{textblock}{0.85}(0.075,0.36)\usebeamerfont{date}
+	\begin{textblock}{0.85}(0.075,0.33)\usebeamerfont{date}
 		{\tiny \color{black}\raggedright{\insertdate}}
 	\end{textblock}
-}
+	\begin{textblock}{0.85}(0.075,0.37)\usebeamerfont{author}
+		{\color{black}\insertauthor}
+	\end{textblock}}
 
 
 % Section page

--- a/inst/rmarkdown/templates/macquarie/skeleton/beamerthememacquarie.sty
+++ b/inst/rmarkdown/templates/macquarie/skeleton/beamerthememacquarie.sty
@@ -97,7 +97,7 @@
 		\includegraphics[width = \backwidth, height = \bottomtitleheight,keepaspectratio=false]{MQfullMQcolors}
 	\end{textblock}
 	\begin{textblock}{0}(\MQlogox/\paperheight, 0.05)
-		\includegraphics[height=\logoheight,width=!,keepaspectratio]{MQ_MAS_HOR_CMYK_POS}
+		\includegraphics[height=\logoheight,width=!,keepaspectratio]{MQ_INT_HOR_RGB_POS}
 	\end{textblock}
 	\begin{textblock}{0.9}(0.075,0.2)\usebeamerfont{title}
 		{\color{black}\raggedright\par\inserttitle}
@@ -126,7 +126,7 @@
 	{\color{black}\raggedright\par\insertsection}
 	\end{textblock}
 	\begin{textblock}{0}(\MQlogox/\paperheight, 0.05)
-		\includegraphics[height=\logoheight,width=!,keepaspectratio]{MQ_MAS_HOR_CMYK_POS}
+		\includegraphics[height=\logoheight,width=!,keepaspectratio]{MQ_INT_HOR_RGB_POS}
 	\end{textblock}
 }
 
@@ -150,7 +150,7 @@
 %\end{textblock}
 \hrule
 \begin{tikzpicture}[remember picture,overlay]
-\node[anchor=north east,xshift=10pt,yshift=5pt] at (current page.north east) {\includegraphics[height=\logoheight, keepaspectratio]{MQ_MAS_HOR_CMYK_POS}};
+\node[anchor=north east,xshift=10pt,yshift=5pt] at (current page.north east) {\includegraphics[height=\logoheight, keepaspectratio]{MQ_INT_HOR_RGB_POS}};
 \end{tikzpicture}
 }
 


### PR DESCRIPTION
The logo included in the template is called MQ_INT_HOR_RGB_POS instead of MQ_MAS_HOR_CMYK_POS. 