### PR TITLE
References are not labelled unless required

### DIFF
--- a/inst/rmarkdown/templates/macquarie/resources/template.tex
+++ b/inst/rmarkdown/templates/macquarie/resources/template.tex
@@ -347,6 +347,8 @@ $endif$
   $endif$
 }
 
+\setbeamertemplate{frametitle continuation}[singleframecheck] %as to avoid numbering when there is only one slide
+
 \begin{document}
 
 % Hide progress bar and footline on titlepage


### PR DESCRIPTION
Hi!

Im a new lecturer of Statistics at MQ. I downloaded and used your template for a set of lectures. I noticed that colleagues were hardcoding "References" in the generated .tex file to, I suspect, get around the fact that "References 1" gets printed due to the fact that 'allowframebreaks' option. 

I have added this line of code so that it only prints "References" if there is one slide of references, else it prints as you had it.

Thanks!

Jack